### PR TITLE
Require 'cells' as a dependency

### DIFF
--- a/lib/cell/hamlit.rb
+++ b/lib/cell/hamlit.rb
@@ -1,3 +1,4 @@
+require "cells"
 require "hamlit"
 
 module Cell


### PR DESCRIPTION
Currently, the 'cells' gem is a dependency, but is not explicitly required.
Implicitly relying on 'cells' to be required by the consuming application causes
an 'uninitialized constant' error when requiring this gem in isolation.

This closes apotonick/cells#374.
